### PR TITLE
Support Shopware 5.7 specs!

### DIFF
--- a/Resources/views/backend/unzer_payment/view/detail/unzer/basket.js
+++ b/Resources/views/backend/unzer_payment/view/detail/unzer/basket.js
@@ -44,13 +44,13 @@ Ext.define('Shopware.apps.UnzerPayment.view.detail.unzer.Basket', {
     typeRenderer: function (value) {
         switch (value) {
             case 'goods':
-                return '{s name=type/goods}{/s}';
+                return '{s name="type/goods"}{/s}';
             case 'voucher':
-                return '{s name=type/voucher}{/s}';
+                return '{s name="type/voucher"}{/s}';
             case 'digital':
-                return '{s name=type/digital}{/s}';
+                return '{s name="type/digital"}{/s}';
             case 'shipment':
-                return '{s name=type/shipment}{/s}';
+                return '{s name="type/shipment"}{/s}';
         }
 
         return value;


### PR DESCRIPTION
Snippets need to be in quotes or PHP 8 will try to devide the names!
https://developers.shopware.com/developers-guide/shopware-5-upgrade-guide-for-developers/#snippets

There are more files without quotes. SW provides a regex to find them